### PR TITLE
Use sanitized value in `isValid`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -59,11 +59,11 @@ function isValid(value) {
     return false;
   }
 
-  return (0, _ssnValidator.isValid)(value) || (0, _itinValidator.isValid)(value) || (0, _einValidator.isValid)(value);
+  return (0, _ssnValidator.isValid)(sanitizedValue) || (0, _itinValidator.isValid)(sanitizedValue) || (0, _einValidator.isValid)(sanitizedValue);
 }
 
 /**
- * Export `mask` funtion.
+ * Export `mask` function.
  */
 
 function mask(value) {

--- a/src/index.js
+++ b/src/index.js
@@ -41,11 +41,11 @@ export function isValid(value) {
     return false;
   }
 
-  return isValidSsn(value) || isValidItin(value) || isValidEin(value);
+  return isValidSsn(sanitizedValue) || isValidItin(sanitizedValue) || isValidEin(sanitizedValue);
 }
 
 /**
- * Export `mask` funtion.
+ * Export `mask` function.
  */
 
 export function mask(value) {


### PR DESCRIPTION
## Description

Use sanitized value in the `isValid` functions.
- `isValidSsn`
- `isValidItin`
- `isValidEin`

Also added  `coverage` to `.gitignore`, I can open a new PR with that if you prefer.