### PR TITLE
Add EU TIN validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # tin-validator
-Validate and mask a U.S. Taxpayer Identification Number (TIN). A TIN may be an Employer Identification Number (EIN), an Individual Taxpayer Identification Number (ITIN) or a Social Security number (SSN).
+Validate and mask Taxpayer Identification Number (TIN) from US and EU countries. A TIN may be an Employer Identification Number (EIN), an Individual Taxpayer Identification Number (ITIN) or a Social Security number (SSN).
+
+Most of the functions default to US country as you can see in the documentation below. Also for US country, `entityType` is not required. When trying to validate EU TIN we need to set both paramenters `country` and `entityType` as TIN format varies from ech country and entity types.
+
+For EU TIN validation, we first try to validate by using an [online API](https://taxation-customs.ec.europa.eu/online-services/online-services-and-databases-taxation/taxpayer-identification-number-tin_en) provided by the European Commisision, if any error is received from this API (for example, if the API is down), then we run our internal validations instead.
 
 ## Status
 
@@ -19,7 +23,10 @@ npm install tin-validator --save
 This method validates if the given value is a valid `Taxpayer Identification Number`.
 
 #### Arguments
-1. `value` _(*)_: The value to validate.
+- `value` _(*)_: The string value to validate.
+- `options` (object, optional):
+  - `country` (string, optional): Country of document to validate (by default, `US`).
+  - `entityType` (string, optional): Possible values: `natural-person` and `legal-entity`. By default: `natural-person`.
 
 #### Returns
 _(boolean)_:  Returns whether the input value is a valid TIN or not.
@@ -38,6 +45,9 @@ isValid('900-70-0000');
 
 isValid('900700000');
 // => true
+
+isValid('123456789', { country: 'PT', entityType: 'natural-person' });
+// => true
 ```
 
 --------------------------------------------------------------------------------
@@ -46,7 +56,10 @@ isValid('900700000');
 This method will help you protect this sensitive piece of information by obfuscating some digits.
 
 #### Arguments
-1. `value` _(*)_: The value to mask.
+- `value` _(*)_: The value to mask.
+- `options` (object, optional):
+  - `country` (string, optional): Country of document to mask (by default, `US`).
+  - `entityType` (string, optional): Regulation entity type (by default, `natural-person`).
 
 #### Returns
 _(string)_: Returns the masked value by replacing value certain digits by 'X'.
@@ -73,7 +86,10 @@ mask('900700000');
 This method will remove all non numeric characters from the value.
 
 #### Arguments
-1. `value` _(*)_: The value to sanitize.
+- `value` _(*)_: The value to sanitize.
+- `options` (object, optional):
+  - `country` (string, optional): Country of document to sanitize (by default, `US`).
+  - `entityType` (string, optional): Regulation entity type (by default, `natural-person`).
 
 #### Returns
 _(string)_: Returns the sanitized value containing only numeric characters.
@@ -100,6 +116,10 @@ npm test
 ## Release process
 
 The release of a version is automated via the [release](https://github.com/uphold/tin-validator/.github/workflows/release.yaml) GitHub workflow. Run it by clicking the "Run workflow" button.
+
+## Upgrading from version 1 to version 2
+
+The methods on version 1 are the same as on version 2. The only change is that the methods were sync, while now they are async.
 
 ## License
 MIT

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "ein-validator": "^1.0.0",
     "itin-validator": "^1.0.0",
+    "node-fetch": "3.3.2",
     "ssn-validator": "^2.0.1"
   },
   "devDependencies": {
@@ -46,9 +47,6 @@
   },
   "engines": {
     "node": ">=20"
-  },
-  "options": {
-    "mocha": "--compilers js:babel-register --recursive --require should"
   },
   "pre-commit": [
     "lint"

--- a/src/clients/eu-tin-validator-client.js
+++ b/src/clients/eu-tin-validator-client.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const fetch = require('node-fetch');
+
+/**
+ * EUTinValidatorClient class.
+ */
+
+class EUTinValidatorClient {
+  /**
+   * Constructor.
+   */
+
+  constructor() {
+    this.url = 'https://ec.europa.eu/taxation_customs/tin/rest-api';
+  }
+
+  /**
+   * Post.
+   */
+
+  async post(path, data) {
+    const response = await this._request(path, data);
+    const body = await response.json();
+
+    return { ...body, status: response.status };
+  }
+
+  _request(path, data) {
+    return fetch(
+      `${this.url}${path}`,
+      {
+        body: JSON.stringify(data),
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        method: 'POST',
+        redirect: 'follow'
+      }
+    );
+  }
+}
+
+/**
+ * Exports.
+ */
+
+module.exports = new EUTinValidatorClient();

--- a/src/validators/abstract-tin-validator.js
+++ b/src/validators/abstract-tin-validator.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Class `AbstractTinValidator`.
+ */
+
+class AbstractTinValidator {
+  /**
+   * Is country supported.
+   */
+
+  isCountrySupported() {
+    throw new Error('Method not implemented');
+  }
+
+  /**
+   * Is Valid.
+   */
+
+  isValid() {
+    throw new Error('Method not implemented');
+  }
+
+  /**
+   * Mask.
+   */
+
+  mask() {
+    throw new Error('Method not implemented');
+  }
+
+  /**
+   * Sanitize.
+   */
+
+  sanitize() {
+    throw new Error('Method not implemented');
+  }
+}
+
+/**
+ * Export.
+ */
+
+module.exports = AbstractTinValidator;

--- a/src/validators/eu-tin-validator.js
+++ b/src/validators/eu-tin-validator.js
@@ -1,0 +1,119 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { configByMemberState } = require('./validators-by-country');
+const AbstractTinValidator = require('./abstract-tin-validator');
+const euTinValidatorClient = require('../clients/eu-tin-validator-client');
+
+/**
+ * Class `EUTinValidator`.
+ */
+
+class EUTinValidator extends AbstractTinValidator {
+  /**
+   * Constructor.
+   */
+
+  constructor() {
+    super();
+
+    this.defaultSanitizePattern = /[.\-/\s]/g;
+    this.defaultMaskPattern = /[\w]/g;
+  }
+
+  /**
+   * Get member state config.
+   */
+
+  getMemberStateConfig(country, entityType = 'natural-person') {
+    const memberStateConfig = configByMemberState[entityType]?.[country] || {};
+
+    if (memberStateConfig.replaceCountry) {
+      return {
+        config: configByMemberState[entityType][memberStateConfig.replaceCountry] || {},
+        memberState: memberStateConfig.renameMemberState || memberStateConfig.replaceCountry
+      };
+    }
+
+    return { config: memberStateConfig, memberState: memberStateConfig.renameMemberState || country };
+  }
+
+  /**
+   * Is country supported.
+   */
+
+  isCountrySupported(country, entityType = 'natural-person') {
+    return !!configByMemberState[entityType]?.[country];
+  }
+
+  /**
+   * Is valid.
+   */
+
+  async isValid(value, { country, entityType }) {
+    const { config, memberState } = this.getMemberStateConfig(country, entityType);
+    const sanitizedValue = this.sanitize(value, config);
+
+    if (config.validateInternally) {
+      return this.runInternalValidatation(sanitizedValue, config);
+    }
+
+    try {
+      const { structureValid, syntaxValid } = await euTinValidatorClient.post('/check-tin-number', {
+        msCode: memberState,
+        tinNumber: sanitizedValue
+      });
+
+      return !!structureValid && !!syntaxValid;
+    } catch (_) {
+      return this.runInternalValidatation(sanitizedValue, config);
+    }
+  }
+
+  /**
+   * Mask.
+   */
+
+  async mask(value, options = {}) {
+    const isValid = await this.isValid(value, options);
+
+    if (!isValid) {
+      throw new Error('Invalid Taxpayer Identification Number');
+    }
+
+    return value.slice(0, value.length - 4).replace(this.defaultMaskPattern, 'X') + value.slice(-4);
+  }
+
+  /**
+   * Validate internal.
+   */
+
+  runInternalValidatation(value, config) {
+    return config.formats.some(format => format.test(value));
+  }
+
+  /**
+   * Sanitize.
+   */
+
+  sanitize(value, { country, entityType, sanitizePattern } = {}) {
+    if (country && entityType) {
+      const { config } = this.getMemberStateConfig(country, entityType);
+
+      sanitizePattern = config.sanitizePattern || sanitizePattern;
+    }
+
+    const pattern = sanitizePattern || this.defaultSanitizePattern;
+
+    return value.toLowerCase().replace(pattern, '');
+  }
+}
+
+/**
+ * Export.
+ */
+
+module.exports = new EUTinValidator();

--- a/src/validators/us-tin-validator.js
+++ b/src/validators/us-tin-validator.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { isValid: isValidEin, mask: maskEin } = require('ein-validator');
+const { isValid: isValidItin, mask: maskItin } = require('itin-validator');
+const { isValid: isValidSsn, mask: maskSsn } = require('ssn-validator');
+const AbstractTinValidator = require('./abstract-tin-validator');
+
+/**
+ * Class `USTinValidator`.
+ */
+
+class USTinValidator extends AbstractTinValidator {
+  /**
+   * Is country supported.
+   */
+
+  isCountrySupported(country) {
+    return country === 'US';
+  }
+
+  /**
+   * Is valid.
+   */
+
+  isValid(value) {
+    return isValidSsn(value) || isValidItin(value) || isValidEin(value);
+  }
+
+  /**
+   * Mask.
+   */
+
+  mask(value) {
+    const isValid = this.isValid(value);
+
+    if (!isValid) {
+      throw new Error('Invalid Taxpayer Identification Number');
+    }
+
+    if (isValidEin(value)) {
+      return maskEin(value);
+    }
+
+    if (isValidItin(value)) {
+      return maskItin(value);
+    }
+
+    if (isValidSsn(value)) {
+      return maskSsn(value);
+    }
+  }
+
+  /**
+   * Sanitize.
+   */
+
+  sanitize(value) {
+    return String(value).replace(/\D+/g, '');
+  }
+}
+
+/**
+ * Exports.
+ */
+
+module.exports = new USTinValidator();

--- a/src/validators/validators-by-country.js
+++ b/src/validators/validators-by-country.js
@@ -1,0 +1,373 @@
+'use strict';
+
+/**
+ * Export validations.
+ */
+
+module.exports = {
+  configByMemberState: {
+    'legal-entity': {
+      // Austria
+      AT: {
+        formats: [/^\d{9}$/],
+        validateInternally: true
+      },
+      // Åland Islands
+      AX: {
+        replaceCountry: 'FI',
+        validateInternally: true
+      },
+      // Belgium
+      BE: {
+        formats: [/^\d{10}$/],
+        validateInternally: true
+      },
+      // Bulgaria
+      BG: {
+        formats: [/^\d{9}$/],
+        validateInternally: true
+      },
+      // Cyprus
+      CY: {
+        formats: [/^\d{8}[a-z]$/],
+        validateInternally: true
+      },
+      // Czechia
+      CZ: {
+        formats: [/^\d{9}$/, /^\d{10}$/],
+        validateInternally: true
+      },
+      // Germany
+      DE: {
+        formats: [/^\d{11}$/],
+        validateInternally: true
+      },
+      // Denmark
+      DK: {
+        formats: [/^\d{8}$/],
+        validateInternally: true
+      },
+      // Estonia
+      EE: {
+        formats: [/^\d{8}$/],
+        validateInternally: true
+      },
+      // Spain
+      ES: {
+        formats: [/^[a-z]\d{8}$/],
+        validateInternally: true
+      },
+      // Finland
+      FI: {
+        formats: [/^\d{8}$/],
+        validateInternally: true
+      },
+      // France
+      FR: {
+        formats: [/^\d{9}$/],
+        validateInternally: true
+      },
+      // United Kingdom
+      GB: {
+        formats: [/^\d{10}$/],
+        validateInternally: true
+      },
+      // French Guiana
+      GF: {
+        replaceCountry: 'FR',
+        validateInternally: true
+      },
+      // Gibraltar
+      GI: {
+        replaceCountry: 'GB',
+        validateInternally: true
+      },
+      // Guadeloupe
+      GP: {
+        replaceCountry: 'FR',
+        validateInternally: true
+      },
+      // Greece
+      GR: {
+        formats: [/^\d{9}$/],
+        renameMemberState: 'EL',
+        validateInternally: true
+      },
+      // Croatia
+      HR: {
+        formats: [/^\d{11}$/],
+        validateInternally: true
+      },
+      // Hungary
+      HU: {
+        formats: [/^\d{11}$/],
+        validateInternally: true
+      },
+      // Ireland
+      IE: {
+        formats: [/^\d{7}[a-z]{1,2}$/, /^chy\d{1,5}$/],
+        validateInternally: true
+      },
+      // Iceland
+      IS: {
+        formats: [/^\d{10}$/],
+        validateInternally: true
+      },
+      // Italy
+      IT: {
+        formats: [/^\d{11}$/],
+        validateInternally: true
+      },
+      // Liechtenstein
+      LI: {
+        formats: [/^5\d{8}$/],
+        validateInternally: true
+      },
+      // Lithuania
+      LT: {
+        formats: [/^\d{9}$/],
+        validateInternally: true
+      },
+      // Luxembourg
+      LU: {
+        formats: [/^\d{11}$/],
+        validateInternally: true
+      },
+      // Latvia
+      LV: {
+        formats: [/^\d{11}$/],
+        validateInternally: true
+      },
+      // Saint Martin
+      MF: {
+        replaceCountry: 'FR',
+        validateInternally: true
+      },
+      // Martinique
+      MQ: {
+        replaceCountry: 'FR',
+        validateInternally: true
+      },
+      // Malta
+      MT: {
+        formats: [/^\d{9}$/],
+        validateInternally: true
+      },
+      // Netherlands
+      NL: {
+        formats: [/^\d{9}$/],
+        validateInternally: true
+      },
+      // Norway
+      NO: {
+        formats: [/^[89]\d{8}$/],
+        validateInternally: true
+      },
+      // Poland
+      PL: {
+        formats: [/^\d{10}$/],
+        validateInternally: true
+      },
+      // Portugal
+      PT: {
+        formats: [/^[56789]\d{8}$/],
+        validateInternally: true
+      },
+      // Réunion
+      RE: {
+        replaceCountry: 'FR',
+        validateInternally: true
+      },
+      // Romania
+      RO: {
+        formats: [/^\d{13}$/],
+        validateInternally: true
+      },
+      // Sweden
+      SE: {
+        formats: [/^\d{10}$/],
+        validateInternally: true
+      },
+      // Slovenia
+      SI: {
+        formats: [/^\d{8}$/],
+        validateInternally: true
+      },
+      // Slovakia
+      SK: {
+        formats: [/^\d{10}$/],
+        validateInternally: true
+      },
+      // Mayotte
+      YT: {
+        replaceCountry: 'FR',
+        validateInternally: true
+      }
+    },
+    'natural-person': {
+      // Austria
+      AT: {
+        formats: [/^\d{9}$/]
+      },
+      // Åland Islands
+      AX: {
+        replaceCountry: 'FI'
+      },
+      // Belgium
+      BE: {
+        formats: [/^\d{11}$/]
+      },
+      // Bulgaria
+      BG: {
+        formats: [/^\d{10}$/]
+      },
+      // Cyprus
+      CY: {
+        formats: [/^\d{8}[a-z]$/]
+      },
+      // Czechia
+      CZ: {
+        formats: [/^\d{9}$/, /^\d{10}$/]
+      },
+      // Germany
+      DE: {
+        formats: [/^\d{11}$/]
+      },
+      // Denmark
+      DK: {
+        formats: [/^\d{10}$/]
+      },
+      // Estonia
+      EE: {
+        formats: [/^\d{11}$/]
+      },
+      // Spain
+      ES: {
+        formats: [/^\d{8}[a-z]$/, /^[klmxyz]\d{7}[a-z]$/]
+      },
+      // Finland
+      FI: {
+        formats: [/^\d{6}[abcdefuvwxy+-]\d{3}[a-z0-9]$/],
+        sanitizePattern: /[./\s]/g
+      },
+      // France
+      FR: {
+        formats: [/^[0123]\d{12}$/]
+      },
+      // United Kingdom
+      GB: {
+        formats: [/^[a-z]{2}\d{6}[a-d]$/, /^\d{10}$/, /^\d{13}$/],
+        validateInternally: true
+      },
+      // French Guiana
+      GF: {
+        replaceCountry: 'FR'
+      },
+      // Gibraltar
+      GI: {
+        replaceCountry: 'GB'
+      },
+      // Guadeloupe
+      GP: {
+        replaceCountry: 'FR'
+      },
+      // Greece
+      GR: {
+        formats: [/^\d{9}$/],
+        renameMemberState: 'EL'
+      },
+      // Croatia
+      HR: {
+        formats: [/^\d{11}$/]
+      },
+      // Hungary
+      HU: {
+        formats: [/^\d{10}$/]
+      },
+      // Ireland
+      IE: {
+        formats: [/^\d{7}[a-z]{1,2}$/]
+      },
+      // Iceland
+      IS: {
+        formats: [/^\d{10}$/],
+        validateInternally: true
+      },
+      // Italy
+      IT: {
+        formats: [/^[a-z]{6}\d{2}[a-z]\d{2}[a-z]\d{3}[a-z]$/]
+      },
+      // Liechtenstein
+      LI: {
+        formats: [/^\d{4,12}$/],
+        sanitizePattern: /[-/\s.a-z]/g,
+        validateInternally: true
+      },
+      // Lithuania
+      LT: {
+        formats: [/^\d{11}$/]
+      },
+      // Luxembourg
+      LU: {
+        formats: [/^\d{13}$/]
+      },
+      // Latvia
+      LV: {
+        formats: [/^\d{11}$/]
+      },
+      // Saint Martin
+      MF: {
+        replaceCountry: 'FR'
+      },
+      // Martinique
+      MQ: {
+        replaceCountry: 'FR'
+      },
+      // Malta
+      MT: {
+        formats: [/^\d{7}[abghlmpz]$/, /^\d{9}$/]
+      },
+      // Netherlands
+      NL: {
+        formats: [/^\d{9}$/]
+      },
+      // Norway
+      NO: {
+        formats: [/^\d{11}$/],
+        validateInternally: true
+      },
+      // Poland
+      PL: {
+        formats: [/^\d{10}$/, /^\d{11}$/]
+      },
+      // Portugal
+      PT: {
+        formats: [/^\d{9}$/]
+      },
+      // Réunion
+      RE: {
+        replaceCountry: 'FR'
+      },
+      // Romania
+      RO: {
+        formats: [/^\d{13}$/]
+      },
+      // Sweden
+      SE: {
+        formats: [/^\d{10}$/]
+      },
+      // Slovenia
+      SI: {
+        formats: [/^\d{8}$/]
+      },
+      // Slovakia
+      SK: {
+        formats: [/^\d{9}$/, /^\d{10}$/]
+      },
+      // Mayotte
+      YT: {
+        replaceCountry: 'FR'
+      }
+    }
+  }
+};

--- a/test/src/clients/eu-tin-validator-client.test.js
+++ b/test/src/clients/eu-tin-validator-client.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const client = require('../../../src/clients/eu-tin-validator-client');
+
+/**
+ * Test `EUTinValidatorClient`.
+ */
+
+describe('EUTinValidatorClient', () => {
+  describe('post()', () => {
+    it('should call `_request()`', async () => {
+      const response = { json: vi.fn(() => ({ foo: 'bar' })), status: 200 };
+
+      vi.spyOn(client, '_request').mockReturnValue(response);
+
+      const result = await client.post('/test', { foo: 'bar' });
+
+      expect(client._request).toHaveBeenCalledTimes(1);
+      expect(client._request).toHaveBeenCalledWith('/test', { foo: 'bar' });
+      expect(result).toEqual({ foo: 'bar', status: 200 });
+    });
+  });
+});

--- a/test/src/validators/eu-tin-validator.test.js
+++ b/test/src/validators/eu-tin-validator.test.js
@@ -1,0 +1,261 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { configByMemberState } = require('../../../src/validators/validators-by-country');
+const { legalEntityTins, naturalPersonTins } = require('./test-cases-by-country');
+const euTinValidator = require('../../../src/validators/eu-tin-validator');
+const euTinValidatorClient = require('../../../src/clients/eu-tin-validator-client');
+
+/**
+ * Test `EUTinValidator`.
+ */
+
+describe('EUTinValidator', () => {
+  describe('getMemberStateConfig()', () => {
+    it('should rename member state to match with the API config', () => {
+      ['natural-person', 'legal-entity'].forEach(entityType => {
+        expect(euTinValidator.getMemberStateConfig('GR', entityType)).toEqual({
+          config: configByMemberState[entityType].GR,
+          memberState: 'EL'
+        });
+      });
+    });
+
+    describe('legal entity', () => {
+      const entityType = 'legal-entity';
+
+      it('should return `replaceCountry` config if it is configured', () => {
+        expect(euTinValidator.getMemberStateConfig('GI', entityType)).toEqual({
+          config: configByMemberState[entityType].GB,
+          memberState: 'GB'
+        });
+      });
+
+      it('should return `config` as empty object if not defined`', () => {
+        expect(euTinValidator.getMemberStateConfig('BO', entityType)).toEqual({
+          config: {},
+          memberState: 'BO'
+        });
+      });
+
+      it('should return member state config`', () => {
+        expect(euTinValidator.getMemberStateConfig('NO', entityType)).toEqual({
+          config: configByMemberState[entityType].NO,
+          memberState: 'NO'
+        });
+      });
+    });
+
+    describe('natural person', () => {
+      const entityType = 'natural-person';
+
+      it('should return `replaceCountry` config if it is configured', () => {
+        expect(euTinValidator.getMemberStateConfig('GI', entityType)).toEqual({
+          config: configByMemberState[entityType].GB,
+          memberState: 'GB'
+        });
+      });
+
+      it('should return `config` as empty object if not defined`', () => {
+        expect(euTinValidator.getMemberStateConfig('BO', entityType)).toEqual({
+          config: {},
+          memberState: 'BO'
+        });
+      });
+
+      it('should return member state config`', () => {
+        expect(euTinValidator.getMemberStateConfig('NO', entityType)).toEqual({
+          config: configByMemberState[entityType].NO,
+          memberState: 'NO'
+        });
+      });
+    });
+  });
+
+  describe('isCountrySupported()', () => {
+    describe('legal entity', () => {
+      const entityType = 'legal-entity';
+
+      it('should return `false` if country is a non EU country', () => {
+        expect(euTinValidator.isCountrySupported('US', entityType)).toBe(false);
+      });
+
+      it('should return `true` if country is a EU country', () => {
+        expect(euTinValidator.isCountrySupported('FR', entityType)).toBe(true);
+      });
+    });
+
+    describe('natural person', () => {
+      const entityType = 'natural-person';
+
+      it('should return `false` if country is a non EU country', () => {
+        expect(euTinValidator.isCountrySupported('US', entityType)).toBe(false);
+      });
+
+      it('should return `true` if country is a EU country', () => {
+        expect(euTinValidator.isCountrySupported('FR', entityType)).toBe(true);
+      });
+    });
+  });
+
+  describe('isValid()', () => {
+    it('should call `runInternalValidatation()` if member state `config.validateInternally` is `true`', async () => {
+      const { config } = euTinValidator.getMemberStateConfig('IS', 'natural-person');
+
+      vi.spyOn(euTinValidator, 'runInternalValidatation').mockReturnValue(false);
+      vi.spyOn(euTinValidatorClient, 'post');
+
+      const result = await euTinValidator.isValid('invalid-tin', { country: 'IS', entityType: 'natural-person' });
+
+      expect(euTinValidator.runInternalValidatation).toHaveBeenCalledTimes(1);
+      expect(euTinValidator.runInternalValidatation).toHaveBeenCalledWith('invalidtin', config);
+      expect(euTinValidatorClient.post).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('should call `euTinValidatorClient.post()`', async () => {
+      vi.spyOn(euTinValidator, 'runInternalValidatation');
+      vi.spyOn(euTinValidatorClient, 'post').mockResolvedValue({ structureValid: true, syntaxValid: true });
+
+      const result = await euTinValidator.isValid('valid-tin', { country: 'FR', entityType: 'natural-person' });
+
+      expect(euTinValidator.runInternalValidatation).not.toHaveBeenCalled();
+      expect(euTinValidatorClient.post).toHaveBeenCalledTimes(1);
+      expect(euTinValidatorClient.post).toHaveBeenCalledWith('/check-tin-number', {
+        msCode: 'FR',
+        tinNumber: 'validtin'
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should call `runInternalValidatation()` if `euTinValidatorClient.post()` throws an error', async () => {
+      const { config } = euTinValidator.getMemberStateConfig('FR', 'natural-person');
+
+      vi.spyOn(euTinValidator, 'runInternalValidatation').mockReturnValue(true);
+      vi.spyOn(euTinValidatorClient, 'post').mockRejectedValue(new Error('Network error'));
+
+      const result = await euTinValidator.isValid('valid-tin', { country: 'FR', entityType: 'natural-person' });
+
+      expect(euTinValidatorClient.post).toHaveBeenCalledTimes(1);
+      expect(euTinValidatorClient.post).toHaveBeenCalledWith('/check-tin-number', {
+        msCode: 'FR',
+        tinNumber: 'validtin'
+      });
+      expect(euTinValidator.runInternalValidatation).toHaveBeenCalledTimes(1);
+      expect(euTinValidator.runInternalValidatation).toHaveBeenCalledWith('validtin', config);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('mask()', () => {
+    it('should throw an error if `tin` is invalid', async () => {
+      vi.spyOn(euTinValidator, 'isValid').mockRejectedValue(new Error('Invalid Taxpayer Identification Number'));
+
+      try {
+        await euTinValidator.mask('foobar', { country: 'FR', entityType: 'natural-person' });
+
+        expect.fail();
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toBe('Invalid Taxpayer Identification Number');
+      }
+    });
+
+    describe('legal entity', () => {
+      const entityType = 'legal-entity';
+
+      test.each(legalEntityTins)('should return masked value for $country TIN', async ({ country, tin }) => {
+        vi.spyOn(euTinValidator, 'isValid').mockResolvedValue(true);
+
+        for (const index in tin.valid) {
+          const maskedTin = await euTinValidator.mask(tin.valid[index], { country, entityType });
+
+          expect(maskedTin).toBe(tin.masked[index]);
+        }
+      });
+    });
+
+    describe('natural person', () => {
+      const entityType = 'natural-person';
+
+      beforeEach(() => {
+        vi.spyOn(euTinValidatorClient, 'post').mockRejectedValue(new Error('Network error'));
+      });
+
+      test.each(naturalPersonTins)('should return masked value for $country TIN', async ({ country, tin }) => {
+        for (const index in tin.valid) {
+          const maskedTin = await euTinValidator.mask(tin.valid[index], { country, entityType });
+
+          expect(maskedTin).toBe(tin.masked[index]);
+        }
+      });
+    });
+  });
+
+  describe('runInternalValidatation()', () => {
+    describe('legal entity', () => {
+      const entityType = 'legal-entity';
+
+      legalEntityTins.forEach(({ country, tin }) => {
+        it(`should return 'true' for valid '${country}' TIN`, () => {
+          tin.valid.forEach(validTin => {
+            const { config } = euTinValidator.getMemberStateConfig(country, entityType);
+            const sanitizedValue = euTinValidator.sanitize(validTin, config);
+
+            expect(euTinValidator.runInternalValidatation(sanitizedValue, config)).toBe(true);
+          });
+        });
+
+        it(`should return 'false' for invalid '${country}' TIN`, () => {
+          tin.invalid.forEach(invalidTin => {
+            const { config } = euTinValidator.getMemberStateConfig(country, entityType);
+            const sanitizedValue = euTinValidator.sanitize(invalidTin, config);
+
+            expect(euTinValidator.runInternalValidatation(sanitizedValue, config)).toBe(false);
+          });
+        });
+      });
+    });
+
+    describe('natural person', () => {
+      const entityType = 'natural-person';
+
+      naturalPersonTins.forEach(({ country, tin }) => {
+        it(`should return 'true' for valid '${country}' TIN`, () => {
+          tin.valid.forEach(validTin => {
+            const { config } = euTinValidator.getMemberStateConfig(country, entityType);
+            const sanitizedValue = euTinValidator.sanitize(validTin, config);
+
+            expect(euTinValidator.runInternalValidatation(sanitizedValue, config)).toBe(true);
+          });
+        });
+
+        it(`should return 'false' for invalid '${country}' TIN`, () => {
+          tin.invalid.forEach(invalidTin => {
+            const { config } = euTinValidator.getMemberStateConfig(country, entityType);
+            const sanitizedValue = euTinValidator.sanitize(invalidTin, config);
+
+            expect(euTinValidator.runInternalValidatation(sanitizedValue, config)).toBe(false);
+          });
+        });
+      });
+    });
+  });
+
+  describe('sanitize()', () => {
+    it('should call `getMemberStateConfig()` if country and entityType are provided', () => {
+      expect(euTinValidator.sanitize('  1234  /-  ABC ', { country: 'FR', entityType: 'natural-person' })).toBe('1234abc');
+    });
+
+    it('should remove unnecessary characters and to lower case', () => {
+      expect(euTinValidator.sanitize('  1234  /-  ABC ')).toBe('1234abc');
+    });
+
+    it('should use custom sanitization pattern', () => {
+      expect(euTinValidator.sanitize('1234-ABC', { sanitizePattern: /[\d-]/g })).toBe('abc');
+    });
+  });
+});

--- a/test/src/validators/test-cases-by-country.js
+++ b/test/src/validators/test-cases-by-country.js
@@ -1,0 +1,717 @@
+/**
+ * Export legal entity TINs.
+ */
+
+module.exports.legalEntityTins = [
+  // Austria
+  {
+    country: 'AT',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Åland Islands
+  {
+    country: 'AX',
+    tin: {
+      invalid: ['1234', 'ABCABCAB', '123456789'],
+      masked: ['XXXX5678'],
+      valid: ['12345678']
+    }
+  },
+  // Belgium
+  {
+    country: 'BE',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Bulgaria
+  {
+    country: 'BG',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Cyprus
+  {
+    country: 'CY',
+    tin: {
+      invalid: ['123456789', 'ABCABCABC', '123456789A'],
+      masked: ['XXXXX678A'],
+      valid: ['12345678A']
+    }
+  },
+  // Czechia
+  {
+    country: 'CZ',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXX6789', 'XXXXXX7890'],
+      valid: ['123456789', '1234567890']
+    }
+  },
+  // Germany
+  {
+    country: 'DE',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Denmark
+  {
+    country: 'DK',
+    tin: {
+      invalid: ['1234', 'ABCABCAB', '123456789'],
+      masked: ['XXXX5678'],
+      valid: ['12345678']
+    }
+  },
+  // Estonia
+  {
+    country: 'EE',
+    tin: {
+      invalid: ['1234', 'ABCABCAB', '123456789'],
+      masked: ['XXXX5678'],
+      valid: ['12345678']
+    }
+  },
+  // Spain
+  {
+    country: 'ES',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '123456789'],
+      masked: ['XXXXX5678'],
+      valid: ['A12345678']
+    }
+  },
+  // Finland
+  {
+    country: 'FI',
+    tin: {
+      invalid: ['1234', 'ABCABCAB', '123456789'],
+      masked: ['XXXX5678'],
+      valid: ['12345678']
+    }
+  },
+  // France
+  {
+    country: 'FR',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // French Guiana
+  {
+    country: 'GF',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // United Kingdom
+  {
+    country: 'GB',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Gibraltar
+  {
+    country: 'GI',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Guadeloupe
+  {
+    country: 'GP',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Greece
+  {
+    country: 'GR',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Croatia
+  {
+    country: 'HR',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Hungary
+  {
+    country: 'HU',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Ireland
+  {
+    country: 'IE',
+    tin: {
+      invalid: ['ABCABCAB', 'ABCABCABC', '12345678', '123456789', '1234567A0', '1234567AB0'],
+      // TODO(vitor.costa): check this short TIN masked.
+      masked: ['XXXX567A', 'XXXXX67AB', 'XXXX2345'],
+      valid: ['1234567A', '1234567AB', 'CHY12345']
+    }
+  },
+  // Iceland
+  {
+    country: 'IS',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Italy
+  {
+    country: 'IT',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Liechtenstein
+  {
+    country: 'LI',
+    tin: {
+      invalid: ['123', 'ABCABCABC', '123456789', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['523456789']
+    }
+  },
+  // Lithuania
+  {
+    country: 'LT',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Luxembourg
+  {
+    country: 'LU',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Latvia
+  {
+    country: 'LV',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Saint Martin
+  {
+    country: 'MF',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Martinique
+  {
+    country: 'MQ',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Malta
+  {
+    country: 'MT',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Netherlands
+  {
+    country: 'NL',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Norway
+  {
+    country: 'NO',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['823456789']
+    }
+  },
+  // Poland
+  {
+    country: 'PL',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Portugal
+  {
+    country: 'PT',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '123456789', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['523456789']
+    }
+  },
+  // Réunion
+  {
+    country: 'RE',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Romania
+  {
+    country: 'RO',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  },
+  // Sweden
+  {
+    country: 'SE',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Slovenia
+  {
+    country: 'SI',
+    tin: {
+      invalid: ['1234', 'ABCABCAB', '123456789'],
+      masked: ['XXXX5678'],
+      valid: ['12345678']
+    }
+  },
+  // Slovakia
+  {
+    country: 'SK',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Mayotte
+  {
+    country: 'YT',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  }
+];
+
+/**
+ * Export natural person TINs.
+ */
+
+module.exports.naturalPersonTins = [
+  // Austria
+  {
+    country: 'AT',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Åland Islands
+  {
+    country: 'AX',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456A12345', '123456+12345', '123456712345'],
+      masked: ['XXXXXXX123A', 'XXXXXXX1230', 'XXXXXX+123A', 'XXXXXX-1230'],
+      valid: ['123456A123A', '123456A1230', '123456+123A', '123456-1230']
+    }
+  },
+  // Belgium
+  {
+    country: 'BE',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Bulgaria
+  {
+    country: 'BG',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Cyprus
+  {
+    country: 'CY',
+    tin: {
+      invalid: ['123456789', 'ABCABCABC', '123456789A'],
+      masked: ['XXXXX678A'],
+      valid: ['12345678A']
+    }
+  },
+  // Czechia
+  {
+    country: 'CZ',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXX6789', 'XXXXXX7890'],
+      valid: ['123456789', '1234567890']
+    }
+  },
+  // Germany
+  {
+    country: 'DE',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Denmark
+  {
+    country: 'DK',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Estonia
+  {
+    country: 'EE',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Spain
+  {
+    country: 'ES',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', 'A1234567', '1234567A', '123456789', 'A1234567A'],
+      masked: ['XXXXX678A', 'XXXXX567A'],
+      valid: ['12345678A', 'K1234567A']
+    }
+  },
+  // Finland
+  {
+    country: 'FI',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456A12345', '123456+12345', '123456712345', '123456P1230', '123456*1230'],
+      masked: ['XXXXXXX123A', 'XXXXXXX1230', 'XXXXXX+123A', 'XXXXXX-123A'],
+      valid: ['123456A123A', '123456A1230', '123456+123A', '123456-123A']
+    }
+  },
+  // France
+  {
+    country: 'FR',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234', '9234567890123'],
+      masked: ['XXXXXXXXX0123', 'XXXXXXXXX0123', 'XXXXXXXXX0123', 'XXXXXXXXX0123'],
+      valid: ['0234567890123', '1234567890123', '2234567890123', '3234567890123']
+    }
+  },
+  // United Kingdom
+  {
+    country: 'GB',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '123456789', 'ABCABCABCA', 'A12345678', 'A1234567Z', 'ABCABCABCABCA', 'A123456789012'],
+      masked: ['XXXXX456A', 'XXXXXX7890', 'XXXXXXXXX0123'],
+      valid: ['AB123456A', '1234567890', '1234567890123']
+    }
+  },
+  // French Guiana
+  {
+    country: 'GF',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  },
+  // Gibraltar
+  {
+    country: 'GI',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '123456789', 'ABCABCABCA', 'A12345678', 'ABCABCABCABCA', 'A123456789012'],
+      masked: ['XXXXX456A', 'XXXXXX7890', 'XXXXXXXXX0123'],
+      valid: ['AB123456A', '1234567890', '1234567890123']
+    }
+  },
+  // Guadeloupe
+  {
+    country: 'GP',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  },
+  // Greece
+  {
+    country: 'GR',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Croatia
+  {
+    country: 'HR',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Hungary
+  {
+    country: 'HU',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Ireland
+  {
+    country: 'IE',
+    tin: {
+      invalid: ['1234', 'ABCABCAB', 'ABCABCABC', '12345678', '123456789', '1234567A0', '1234567AB0'],
+      masked: ['XXXX567A', 'XXXXX67AB'],
+      valid: ['1234567A', '1234567AB']
+    }
+  },
+  // Iceland
+  {
+    country: 'IS',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Italy
+  {
+    country: 'IT',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCABCA', 'ABCDEF12A12A123AA', '1234567890123456'],
+      masked: ['XXXXXXXXXXXX123A'],
+      valid: ['ABCDEF12A12A123A']
+    }
+  },
+  // Liechtenstein
+  {
+    country: 'LI',
+    tin: {
+      invalid: ['123', 'ABCA', 'ABCABC', 'ABCABCABCABC', '1234567890123'],
+      // TODO(vitor.costa): check this short TIN masked and the one with dash and dot.
+      masked: ['1234', 'XX3456', 'XXXXXXXX9012', 'XX-XXX.456'],
+      valid: ['1234', '123456', '123456789012', 'FL-123.456']
+    }
+  },
+  // Lithuania
+  {
+    country: 'LT',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Luxembourg
+  {
+    country: 'LU',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  },
+  // Latvia
+  {
+    country: 'LV',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Saint Martin
+  {
+    country: 'MF',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  },
+  // Martinique
+  {
+    country: 'MQ',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  },
+  // Malta
+  {
+    country: 'MT',
+    tin: {
+      invalid: ['1234', 'ABCABCAB', 'ABCABCABC', '12345678', '1234567890', '1234567K'],
+      masked: ['XXXX567A', 'XXXXX6789'],
+      valid: ['1234567A', '123456789']
+    }
+  },
+  // Netherlands
+  {
+    country: 'NL',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Norway
+  {
+    country: 'NO',
+    tin: {
+      invalid: ['1234', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXXX8901'],
+      valid: ['12345678901']
+    }
+  },
+  // Poland
+  {
+    country: 'PL',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', 'ABCABCABCAB', '123456789012'],
+      masked: ['XXXXXX7890', 'XXXXXXX8901'],
+      valid: ['1234567890', '12345678901']
+    }
+  },
+  // Portugal
+  {
+    country: 'PT',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', '1234567890'],
+      masked: ['XXXXX6789'],
+      valid: ['123456789']
+    }
+  },
+  // Réunion
+  {
+    country: 'RE',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  },
+  // Romania
+  {
+    country: 'RO',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  },
+  // Sweden
+  {
+    country: 'SE',
+    tin: {
+      invalid: ['1234', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXXX7890'],
+      valid: ['1234567890']
+    }
+  },
+  // Slovenia
+  {
+    country: 'SI',
+    tin: {
+      invalid: ['1234', 'ABCABCAB', '123456789'],
+      masked: ['XXXX5678'],
+      valid: ['12345678']
+    }
+  },
+  // Slovakia
+  {
+    country: 'SK',
+    tin: {
+      invalid: ['1234', 'ABCABCABC', 'ABCABCABCA', '12345678901'],
+      masked: ['XXXXX6789', 'XXXXXX7890'],
+      valid: ['123456789', '1234567890']
+    }
+  },
+  // Mayotte
+  {
+    country: 'YT',
+    tin: {
+      invalid: ['1234', 'ABCABCABCABCA', '12345678901234'],
+      masked: ['XXXXXXXXX0123'],
+      valid: ['1234567890123']
+    }
+  }
+];

--- a/test/src/validators/us-tin-validator.test.js
+++ b/test/src/validators/us-tin-validator.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const usTinValidator = require('../../../src/validators/us-tin-validator');
+
+/**
+ * Constants.
+ */
+
+const ein = '66-0000000';
+const itin = '969-88-9999';
+const ssn = '001-23-4567';
+
+/**
+ * Test `USTinValidator`.
+ */
+
+describe('USTinValidator', () => {
+  describe('isCountrySupported()', () => {
+    it('should return `false` if country is not `US`', () => {
+      expect(usTinValidator.isCountrySupported('BO')).toBe(false);
+    });
+
+    it('should return `true` if country is `US`', () => {
+      expect(usTinValidator.isCountrySupported('US')).toBe(true);
+    });
+  });
+
+  describe('isValid()', () => {
+    it('should return `false` is `tin` is invalid', () => {
+      expect(usTinValidator.isValid('invalid-tin')).toBe(false);
+    });
+
+    it('should return `true` is `tin` is a valid `ein`', () => {
+      expect(usTinValidator.isValid(ein)).toBe(true);
+    });
+
+    it('should return `true` is `tin` is a valid `itin`', () => {
+      expect(usTinValidator.isValid(itin)).toBe(true);
+    });
+
+    it('should return `true` is `tin` is a valid `ssn`', () => {
+      expect(usTinValidator.isValid(ssn)).toBe(true);
+    });
+  });
+
+  describe('mask()', () => {
+    it('should throw an error if `tin` is invalid', () => {
+      try {
+        usTinValidator.mask('foobar');
+
+        expect.fail();
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toBe('Invalid Taxpayer Identification Number');
+      }
+    });
+
+    it('should return a masked `ein`', () => {
+      expect(usTinValidator.mask(ein)).toBe('XX-XXX0000');
+    });
+
+    it('should return a masked `itin`', () => {
+      expect(usTinValidator.mask(itin)).toBe('XXX-XX-9999');
+    });
+
+    it('should return a masked `ssn`', () => {
+      expect(usTinValidator.mask(ssn)).toBe('XXX-XX-4567');
+    });
+  });
+
+  describe('sanitize()', () => {
+    it('should remove unnecessary characters and letters', () => {
+      expect(usTinValidator.sanitize('  1234  /-  ABC ')).toBe('1234');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,6 +1329,11 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 data-uri-to-buffer@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
@@ -1809,6 +1814,14 @@ fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -1836,6 +1849,13 @@ flatted@^3.2.9:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
@@ -2364,10 +2384,24 @@ new-github-release-url@2.0.0:
   dependencies:
     type-fest "^2.5.1"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch-native@^1.6.6:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.7.tgz#9d09ca63066cc48423211ed4caf5d70075d76a71"
   integrity sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==
+
+node-fetch@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-releases@^2.0.19:
   version "2.0.19"
@@ -3035,6 +3069,11 @@ vitest@4.0.6:
     tinyrainbow "^3.0.3"
     vite "^6.0.0 || ^7.0.0"
     why-is-node-running "^2.3.0"
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
PR adds required validations for EU TINS, we do so by requesting an open API. If any error occurs during request we fallback to our internal validation. Internal validation was coded by following the TIN guide found in European Commission website. Open API also belongs to this commission and it is described in it website too. Finally we do a restructure on the files in order to have a better modularization.

European Commission [API Doc](https://ec.europa.eu/taxation_customs/tin/#/technical-information) and [TIN per country formats](https://taxation-customs.ec.europa.eu/online-services/online-services-and-databases-taxation/taxpayer-identification-number-tin_en).