### PR TITLE
Validate Bulgaria natural persons internally

### DIFF
--- a/src/validators/validators-by-country.js
+++ b/src/validators/validators-by-country.js
@@ -219,7 +219,8 @@ module.exports = {
       },
       // Bulgaria
       BG: {
-        formats: [/^\d{10}$/]
+        formats: [/^\d{10}$/],
+        validateInternally: true
       },
       // Cyprus
       CY: {


### PR DESCRIPTION
The European union API to validate TINs do not work for foreigners living in Bulgaria that have to submit a personal foreigner number. Given the API answer is the same as an incorrect TIN we can’t rely on it to verify Bulgarian TINs. 
We fix this issue by setting BG TIN checks for `natural-persons` in `tin-validator` with `validateInternally: true`, forcing to run your internal check instead of European union API call.

Ticket:
https://uphold.atlassian.net/browse/BKO-6360