### PR TITLE
Skip validations on mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This method validates if the given value is a valid `Taxpayer Identification Num
 - `options` (object, optional):
   - `country` (string, optional): Country of document to validate (by default, `US`).
   - `entityType` (string, optional): Possible values: `natural-person` and `legal-entity`. By default: `natural-person`.
-  - `skipExternalValidations` (boolean, optional): When set to `true`, skips external API validation and uses only internal validation. This is useful for performance, offline scenarios, or testing. By default: `false`.
+  - `skipExternalValidations` (boolean, optional): Only applicable for EU TIN. When set to `true`, it skips external API validation and uses only internal validation. This is useful for performance, offline scenarios, or testing. By default: `false`.
 
 #### Returns
 _(boolean)_:  Returns whether the input value is a valid TIN or not.
@@ -61,7 +61,8 @@ This method will help you protect this sensitive piece of information by obfusca
 - `options` (object, optional):
   - `country` (string, optional): Country of document to mask (by default, `US`).
   - `entityType` (string, optional): Regulation entity type (by default, `natural-person`).
-  - `skipExternalValidations` (boolean, optional): When set to `true`, skips external API validation and uses only internal validation. This is useful for performance, offline scenarios, or testing. By default: `false`.
+  - `skipExternalValidations` (boolean, optional): Only applicable for EU TIN. When set to `true`, it skips external API validation and uses only internal validation. This is useful for performance, offline scenarios, or testing. By default: `false`.
+  - `skipValidations` (boolean, optional): Applicable for US and EU TIN. When set to `true`, it skips all kind of validations. This is useful when calling `mask()` after calling `isValid()`. By default: `false`.
 
 #### Returns
 _(string)_: Returns the masked value by replacing value certain digits by 'X'.

--- a/src/index.js
+++ b/src/index.js
@@ -74,17 +74,18 @@ module.exports.isValid = async (value, { country = defaultCountry, entityType = 
  * Export `mask` funtion.
  */
 
-module.exports.mask = async (value, { 
-    country = defaultCountry,
-    entityType = defaultEntityType,
-    skipExternalValidations = false
-  } = {}) => {
+module.exports.mask = async (value, {
+  country = defaultCountry,
+  entityType = defaultEntityType,
+  skipExternalValidations = false,
+  skipValidations = false
+} = {}) => {
   if (usTinValidator.isCountrySupported(country)) {
-    return usTinValidator.mask(value);
+    return usTinValidator.mask(value, { skipValidations });
   }
 
   if (euTinValidator.isCountrySupported(country)) {
-    return await euTinValidator.mask(value, { country, entityType, skipExternalValidations });
+    return await euTinValidator.mask(value, { country, entityType, skipExternalValidations, skipValidations });
   }
 
   return value;

--- a/src/validators/eu-tin-validator.js
+++ b/src/validators/eu-tin-validator.js
@@ -82,10 +82,13 @@ class EUTinValidator extends AbstractTinValidator {
 
   async mask(value, options = {}) {
     const upperCaseValue = value.toUpperCase();
-    const isValid = await this.isValid(upperCaseValue, options);
 
-    if (!isValid) {
-      throw new Error('Invalid Taxpayer Identification Number');
+    if (!options.skipValidations) {
+      const isValid = await this.isValid(upperCaseValue, options);
+
+      if (!isValid) {
+        throw new Error('Invalid Taxpayer Identification Number');
+      }
     }
 
     return upperCaseValue.slice(0, upperCaseValue.length - 4).replace(this.defaultMaskPattern, 'X') + upperCaseValue.slice(-4);

--- a/src/validators/us-tin-validator.js
+++ b/src/validators/us-tin-validator.js
@@ -34,11 +34,13 @@ class USTinValidator extends AbstractTinValidator {
    * Mask.
    */
 
-  mask(value) {
-    const isValid = this.isValid(value);
+  mask(value, options = {}) {
+    if (!options.skipValidations) {
+      const isValid = this.isValid(value);
 
-    if (!isValid) {
-      throw new Error('Invalid Taxpayer Identification Number');
+      if (!isValid) {
+        throw new Error('Invalid Taxpayer Identification Number');
+      }
     }
 
     if (isValidEin(value)) {

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -66,37 +66,73 @@ describe('tin-validator', () => {
   });
 
   describe('mask()', () => {
-    it('should call `usTinValidator.mask()` if `country` is `US`', async () => {
-      vi.spyOn(usTinValidator, 'mask').mockReturnValue(true);
-
-      await mask('66-0000000', { country: 'US', entityType: 'natural-person' });
-
-      expect(usTinValidator.mask).toHaveBeenCalledTimes(1);
-      expect(usTinValidator.mask).toHaveBeenCalledWith('66-0000000');
-    });
-
-    it('should call `euTinValidator.mask()` if `country` is an EU member', async () => {
-      vi.spyOn(euTinValidator, 'mask').mockReturnValue(true);
-
-      await mask('66-0000000', { country: 'FR', entityType: 'natural-person' });
-
-      expect(euTinValidator.mask).toHaveBeenCalledTimes(1);
-      expect(euTinValidator.mask).toHaveBeenCalledWith('66-0000000', expect.objectContaining({ country: 'FR', entityType: 'natural-person' }));
-    });
-
-    it('should pass `skipExternalValidations` flag to `euTinValidator.mask()`', async () => {
-      vi.spyOn(euTinValidator, 'mask').mockReturnValue(true);
-
-      await mask('66-0000000', { country: 'FR', entityType: 'natural-person', skipExternalValidations: true });
-
-      expect(euTinValidator.mask).toHaveBeenCalledTimes(1);
-      expect(euTinValidator.mask).toHaveBeenCalledWith('66-0000000', { country: 'FR', entityType: 'natural-person', skipExternalValidations: true });
-    });
-
-    it('should return unmasked TIN for any other country', async () => {
+    it('should return unmasked TIN if `country` is not `US` or an EU member', async () => {
       const result = await mask('16-182749', { country: 'BO', entityType: 'natural-person' });
 
       expect(result).toBe('16-182749');
+    });
+
+    describe('US TIN', () => {
+      const country = 'US';
+
+      it('should call `usTinValidator.mask()`', async () => {
+        vi.spyOn(usTinValidator, 'mask').mockReturnValue(true);
+
+        await mask('66-0000000', { country });
+
+        expect(usTinValidator.mask).toHaveBeenCalledTimes(1);
+        expect(usTinValidator.mask).toHaveBeenCalledWith('66-0000000', { skipValidations: false });
+      });
+
+      it('should call `usTinValidator.mask()` with `options.skipValidations` if provided', async () => {
+        vi.spyOn(usTinValidator, 'mask').mockReturnValue(true);
+
+        await mask('66-0000000', { country, skipValidations: true });
+
+        expect(usTinValidator.mask).toHaveBeenCalledTimes(1);
+        expect(usTinValidator.mask).toHaveBeenCalledWith('66-0000000', { skipValidations: true });
+      });
+    });
+
+    describe('EU TIN', () => {
+      const country = 'FR';
+
+      it('should call `euTinValidator.mask()` if `country` is an EU member', async () => {
+        vi.spyOn(euTinValidator, 'mask').mockReturnValue(true);
+
+        await mask('66-0000000', { country, entityType: 'natural-person' });
+
+        expect(euTinValidator.mask).toHaveBeenCalledTimes(1);
+        expect(euTinValidator.mask).toHaveBeenCalledWith('66-0000000', expect.objectContaining({ country: 'FR', entityType: 'natural-person' }));
+      });
+
+      it('should call `euTinValidator.mask()` with `options.skipExternalValidations` if provided', async () => {
+        vi.spyOn(euTinValidator, 'mask').mockReturnValue(true);
+
+        await mask('66-0000000', { country, entityType: 'natural-person', skipExternalValidations: true });
+
+        expect(euTinValidator.mask).toHaveBeenCalledTimes(1);
+        expect(euTinValidator.mask).toHaveBeenCalledWith('66-0000000', {
+          country,
+          entityType: 'natural-person',
+          skipExternalValidations: true,
+          skipValidations: false,
+        });
+      });
+
+      it('should call `euTinValidator.mask()` with `options.skipValidations` if provided', async () => {
+        vi.spyOn(euTinValidator, 'mask').mockReturnValue(true);
+
+        await mask('66-0000000', { country, entityType: 'natural-person', skipValidations: true });
+
+        expect(euTinValidator.mask).toHaveBeenCalledTimes(1);
+        expect(euTinValidator.mask).toHaveBeenCalledWith('66-0000000', {
+          country,
+          entityType: 'natural-person',
+          skipExternalValidations: false,
+          skipValidations: true
+        });
+      });
     });
   });
 

--- a/test/src/validators/eu-tin-validator.test.js
+++ b/test/src/validators/eu-tin-validator.test.js
@@ -195,7 +195,15 @@ describe('EUTinValidator', () => {
   });
 
   describe('mask()', () => {
-    it('should pass `skipExternalValidations` flag to `isValid()`', async () => {
+    it('should not call `isValid()` if `options.skipValidations` is `true`', async () => {
+      vi.spyOn(euTinValidator, 'isValid');
+
+      await euTinValidator.mask('1234567ab', { country: 'FR', entityType: 'natural-person', skipValidations: true });
+
+      expect(euTinValidator.isValid).not.toHaveBeenCalled();
+    });
+
+    it('should call `isValid()` if `options.skipExternalValidations` is `true`', async () => {
       vi.spyOn(euTinValidator, 'isValid').mockResolvedValue(true);
 
       await euTinValidator.mask('1234567ab', { country: 'FR', entityType: 'natural-person', skipExternalValidations: true });
@@ -218,9 +226,7 @@ describe('EUTinValidator', () => {
     });
 
     it('should uppercase value', async () => {
-      vi.spyOn(euTinValidator, 'isValid').mockResolvedValue(true);
-
-      const maskedValue = await euTinValidator.mask('1234567ab', { country: 'IE', entityType: 'legal-entity' });
+      const maskedValue = await euTinValidator.mask('1234567ab', { country: 'IE', entityType: 'legal-entity', skipValidations: true });
 
 
       expect(maskedValue).toBe('XXXXX67AB');
@@ -230,10 +236,8 @@ describe('EUTinValidator', () => {
       const entityType = 'legal-entity';
 
       test.each(legalEntityTins)('should return masked value for $country TIN', async ({ country, tin }) => {
-        vi.spyOn(euTinValidator, 'isValid').mockResolvedValue(true);
-
         for (const index in tin.valid) {
-          const maskedTin = await euTinValidator.mask(tin.valid[index], { country, entityType });
+          const maskedTin = await euTinValidator.mask(tin.valid[index], { country, entityType, skipValidations: true });
 
           expect(maskedTin).toBe(tin.masked[index]);
         }
@@ -243,13 +247,9 @@ describe('EUTinValidator', () => {
     describe('natural person', () => {
       const entityType = 'natural-person';
 
-      beforeEach(() => {
-        vi.spyOn(euTinValidatorClient, 'post').mockRejectedValue(new Error('Network error'));
-      });
-
       test.each(naturalPersonTins)('should return masked value for $country TIN', async ({ country, tin }) => {
         for (const index in tin.valid) {
-          const maskedTin = await euTinValidator.mask(tin.valid[index], { country, entityType });
+          const maskedTin = await euTinValidator.mask(tin.valid[index], { country, entityType, skipValidations: true });
 
           expect(maskedTin).toBe(tin.masked[index]);
         }

--- a/test/src/validators/us-tin-validator.test.js
+++ b/test/src/validators/us-tin-validator.test.js
@@ -48,6 +48,14 @@ describe('USTinValidator', () => {
   });
 
   describe('mask()', () => {
+    it('should not call `isValid()` if `options.skipValidations` is `true`', () => {
+      vi.spyOn(usTinValidator, 'isValid');
+
+      usTinValidator.mask(ein, { skipValidations: true });
+
+      expect(usTinValidator.isValid).not.toHaveBeenCalled();
+    });
+
     it('should throw an error if `tin` is invalid', () => {
       try {
         usTinValidator.mask('foobar');


### PR DESCRIPTION
PR removes validations for EU TIN before masking, users should suppose to validate a TIN before masking.

https://uphold.atlassian.net/browse/BKO-6564