### PR TITLE
Add `standardize` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ sanitize('900a7#$0foobar0000');
 
 --------------------------------------------------------------------------------
 
+### `standardize(value)`
+This method will standardize TIN values. Validators may accept TIN values for specific countries with formatting variations (e.g. omitting prefixes of zeros). Users should invoke this method prior value masking and DB persistence, as it returns the official version of the TIN.
+
+#### Arguments
+- `value` _(*)_: The value to standardize.
+- `options` (object, optional):
+  - `country` (string, optional): Country of document to standardize (by default, `US`).
+  - `entityType` (string, optional): Regulation entity type (by default, `natural-person`).
+
+#### Returns
+_(string)_: Returns the standardized value.
+
+#### Example
+
+```js
+standardize('123A', { country: 'MT' });
+// => 0000123A
+
+standardize('123456789');
+// => 123456789
+```
+
+--------------------------------------------------------------------------------
+
 ## Tests
 To test using a local installation of `node.js`:
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const runBasicValidation = value => {
 };
 
 /**
- * Export `isValid` function.
+ * Export `isValid`.
  */
 
 module.exports.isValid = async (value, { country = defaultCountry, entityType = defaultEntityType, skipExternalValidations = false } = {}) => {
@@ -71,7 +71,7 @@ module.exports.isValid = async (value, { country = defaultCountry, entityType = 
 };
 
 /**
- * Export `mask` funtion.
+ * Export `mask`.
  */
 
 module.exports.mask = async (value, {
@@ -92,7 +92,7 @@ module.exports.mask = async (value, {
 };
 
 /**
- * Export `sanitize` function.
+ * Export `sanitize`.
  */
 
 module.exports.sanitize = (value, { country = defaultCountry, entityType = defaultEntityType } = {}) => {
@@ -102,6 +102,18 @@ module.exports.sanitize = (value, { country = defaultCountry, entityType = defau
 
   if (euTinValidator.isCountrySupported(country)) {
     return euTinValidator.sanitize(value, { country, entityType });
+  }
+
+  return value;
+};
+
+/**
+ * Export `standardize`.
+ */
+
+module.exports.standardize = (value, { country = defaultCountry, entityType = defaultEntityType } = {}) => {
+  if (euTinValidator.isCountrySupported(country)) {
+    return euTinValidator.standardize(value, { country, entityType });
   }
 
   return value;

--- a/src/validators/eu-tin-validator.js
+++ b/src/validators/eu-tin-validator.js
@@ -33,7 +33,7 @@ class EUTinValidator extends AbstractTinValidator {
 
     if (memberStateConfig.replaceCountry) {
       return {
-        config: configByMemberState[entityType][memberStateConfig.replaceCountry] || {},
+        config: configByMemberState[entityType][memberStateConfig.replaceCountry],
         memberState: memberStateConfig.renameMemberState || memberStateConfig.replaceCountry
       };
     }
@@ -116,6 +116,18 @@ class EUTinValidator extends AbstractTinValidator {
     const pattern = sanitizePattern || this.defaultSanitizePattern;
 
     return value.toUpperCase().replace(pattern, '');
+  }
+
+  /**
+   * Standardize.
+   */
+
+  standardize(value, { country, entityType } = {}) {
+    const { config } = this.getMemberStateConfig(country, entityType);
+
+    value = this.sanitize(value, { country, entityType });
+
+    return config?.standardize?.(value) || value;
   }
 }
 

--- a/src/validators/validators-by-country.js
+++ b/src/validators/validators-by-country.js
@@ -326,7 +326,17 @@ module.exports = {
       },
       // Malta
       MT: {
-        formats: [/^\d{7}[ABGHLMPZ]$/, /^\d{9}$/]
+        formats: [/^\d{7}[ABGHLMPZ]$/, /^\d{9}$/],
+        standardize: value => {
+          if (/^\d{3,7}[ABGHLMPZ]$/i.test(value)) {
+            const digits = value.slice(0, -1);
+            const letter = value.slice(-1);
+
+            return digits.padStart(7, '0') + letter;
+          }
+
+          return value;
+        }
       },
       // Netherlands
       NL: {

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -4,8 +4,8 @@
  * Module dependencies.
  */
 
-const { isValid, mask, sanitize } = require('../../src');
 const euTinValidator = require('../../src/validators/eu-tin-validator');
+const tinValidator = require('../../src');
 const usTinValidator = require('../../src/validators/us-tin-validator');
 
 /**
@@ -22,7 +22,7 @@ describe('tin-validator', () => {
   describe('isValid()', () => {
     it('should return `false` for invalid TINs', async () => {
       for (const tin of invalidTins) {
-        const result = await isValid(tin);
+        const result = await tinValidator.isValid(tin);
 
         expect(result).toBe(false);
       }
@@ -31,7 +31,7 @@ describe('tin-validator', () => {
     it('should call `usTinValidator.isValid()` if `country` is `US`', async () => {
       vi.spyOn(usTinValidator, 'isValid').mockReturnValue(true);
 
-      const result = await isValid('66-0000000', { country: 'US', entityType: 'natural-person' });
+      const result = await tinValidator.isValid('66-0000000', { country: 'US', entityType: 'natural-person' });
 
       expect(result).toBe(true);
       expect(usTinValidator.isValid).toHaveBeenCalledTimes(1);
@@ -41,7 +41,7 @@ describe('tin-validator', () => {
     it('should call `euTinValidator.isValid()` if `country` is an EU member', async () => {
       vi.spyOn(euTinValidator, 'isValid').mockReturnValue(true);
 
-      const result = await isValid('66-0000000', { country: 'FR', entityType: 'natural-person' });
+      const result = await tinValidator.isValid('66-0000000', { country: 'FR', entityType: 'natural-person' });
 
       expect(result).toBe(true);
       expect(euTinValidator.isValid).toHaveBeenCalledTimes(1);
@@ -51,7 +51,7 @@ describe('tin-validator', () => {
     it('should pass `skipExternalValidations` flag to `euTinValidator.isValid()`', async () => {
       vi.spyOn(euTinValidator, 'isValid').mockReturnValue(true);
 
-      const result = await isValid('66-0000000', { country: 'FR', entityType: 'natural-person', skipExternalValidations: true });
+      const result = await tinValidator.isValid('66-0000000', { country: 'FR', entityType: 'natural-person', skipExternalValidations: true });
 
       expect(result).toBe(true);
       expect(euTinValidator.isValid).toHaveBeenCalledTimes(1);
@@ -59,7 +59,7 @@ describe('tin-validator', () => {
     });
 
     it('should return `true` for any other country', async () => {
-      const result = await isValid('16-182749', { country: 'BO', entityType: 'natural-person' });
+      const result = await tinValidator.isValid('16-182749', { country: 'BO', entityType: 'natural-person' });
 
       expect(result).toBe(true);
     });
@@ -67,7 +67,7 @@ describe('tin-validator', () => {
 
   describe('mask()', () => {
     it('should return unmasked TIN if `country` is not `US` or an EU member', async () => {
-      const result = await mask('16-182749', { country: 'BO', entityType: 'natural-person' });
+      const result = await tinValidator.mask('16-182749', { country: 'BO', entityType: 'natural-person' });
 
       expect(result).toBe('16-182749');
     });
@@ -78,7 +78,7 @@ describe('tin-validator', () => {
       it('should call `usTinValidator.mask()`', async () => {
         vi.spyOn(usTinValidator, 'mask').mockReturnValue(true);
 
-        await mask('66-0000000', { country });
+        await tinValidator.mask('66-0000000', { country });
 
         expect(usTinValidator.mask).toHaveBeenCalledTimes(1);
         expect(usTinValidator.mask).toHaveBeenCalledWith('66-0000000', { skipValidations: false });
@@ -87,7 +87,7 @@ describe('tin-validator', () => {
       it('should call `usTinValidator.mask()` with `options.skipValidations` if provided', async () => {
         vi.spyOn(usTinValidator, 'mask').mockReturnValue(true);
 
-        await mask('66-0000000', { country, skipValidations: true });
+        await tinValidator.mask('66-0000000', { country, skipValidations: true });
 
         expect(usTinValidator.mask).toHaveBeenCalledTimes(1);
         expect(usTinValidator.mask).toHaveBeenCalledWith('66-0000000', { skipValidations: true });
@@ -100,7 +100,7 @@ describe('tin-validator', () => {
       it('should call `euTinValidator.mask()` if `country` is an EU member', async () => {
         vi.spyOn(euTinValidator, 'mask').mockReturnValue(true);
 
-        await mask('66-0000000', { country, entityType: 'natural-person' });
+        await tinValidator.mask('66-0000000', { country, entityType: 'natural-person' });
 
         expect(euTinValidator.mask).toHaveBeenCalledTimes(1);
         expect(euTinValidator.mask).toHaveBeenCalledWith('66-0000000', expect.objectContaining({ country: 'FR', entityType: 'natural-person' }));
@@ -109,7 +109,7 @@ describe('tin-validator', () => {
       it('should call `euTinValidator.mask()` with `options.skipExternalValidations` if provided', async () => {
         vi.spyOn(euTinValidator, 'mask').mockReturnValue(true);
 
-        await mask('66-0000000', { country, entityType: 'natural-person', skipExternalValidations: true });
+        await tinValidator.mask('66-0000000', { country, entityType: 'natural-person', skipExternalValidations: true });
 
         expect(euTinValidator.mask).toHaveBeenCalledTimes(1);
         expect(euTinValidator.mask).toHaveBeenCalledWith('66-0000000', {
@@ -123,7 +123,7 @@ describe('tin-validator', () => {
       it('should call `euTinValidator.mask()` with `options.skipValidations` if provided', async () => {
         vi.spyOn(euTinValidator, 'mask').mockReturnValue(true);
 
-        await mask('66-0000000', { country, entityType: 'natural-person', skipValidations: true });
+        await tinValidator.mask('66-0000000', { country, entityType: 'natural-person', skipValidations: true });
 
         expect(euTinValidator.mask).toHaveBeenCalledTimes(1);
         expect(euTinValidator.mask).toHaveBeenCalledWith('66-0000000', {
@@ -140,7 +140,7 @@ describe('tin-validator', () => {
     it('should call `usTinValidator.sanitize()` if `country` is `US`', async () => {
       vi.spyOn(usTinValidator, 'sanitize');
 
-      const value = await sanitize('66-0000000');
+      const value = await tinValidator.sanitize('66-0000000');
 
       expect(usTinValidator.sanitize).toHaveBeenCalledTimes(1);
       expect(usTinValidator.sanitize).toHaveBeenCalledWith('66-0000000');
@@ -150,7 +150,7 @@ describe('tin-validator', () => {
     it('should call `euTinValidator.sanitize()` if `country` is an EU member', async () => {
       vi.spyOn(euTinValidator, 'sanitize');
 
-      const value = await sanitize('66-0000/000.', { country: 'FR', entityType: 'natural-person' });
+      const value = await tinValidator.sanitize('66-0000/000.', { country: 'FR', entityType: 'natural-person' });
 
       expect(euTinValidator.sanitize).toHaveBeenCalledTimes(1);
       expect(euTinValidator.sanitize).toHaveBeenCalledWith('66-0000/000.', { country: 'FR', entityType: 'natural-person' });
@@ -158,9 +158,36 @@ describe('tin-validator', () => {
     });
 
     it('should return the same value for any other country', async () => {
-      const result = await sanitize('16-182749', { country: 'BO', entityType: 'natural-person' });
+      const result = await tinValidator.sanitize('16-182749', { country: 'BO', entityType: 'natural-person' });
 
       expect(result).toBe('16-182749');
+    });
+  });
+
+  describe('standardize()', () => {
+    it('should call `euTinValidator.standardize()` if `country` is an EU member', async () => {
+      const value = '12345678901';
+      const country = 'BE';
+
+      vi.spyOn(euTinValidator, 'standardize').mockReturnValue(value);
+
+      const normalizedValue = await tinValidator.standardize(value, { country, entityType: 'natural-person' });
+
+      expect(normalizedValue).toBe(value);
+      expect(euTinValidator.standardize).toHaveBeenCalledTimes(1);
+      expect(euTinValidator.standardize).toHaveBeenCalledWith(value, { country, entityType: 'natural-person' });
+    });
+
+    it('should return same value if `country` is not an EU member', async () => {
+      const value = 'foobar';
+      const country = 'foo';
+
+      vi.spyOn(euTinValidator, 'standardize');
+
+      const normalizedValue = await tinValidator.standardize(value, { country, entityType: 'natural-person' });
+
+      expect(normalizedValue).toBe(value);
+      expect(euTinValidator.standardize).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/src/validators/eu-tin-validator.test.js
+++ b/test/src/validators/eu-tin-validator.test.js
@@ -213,7 +213,7 @@ describe('EUTinValidator', () => {
     });
 
     it('should throw an error if `tin` is invalid', async () => {
-      vi.spyOn(euTinValidator, 'isValid').mockRejectedValue(new Error('Invalid Taxpayer Identification Number'));
+      vi.spyOn(euTinValidator, 'isValid').mockResolvedValue(false);
 
       try {
         await euTinValidator.mask('foobar', { country: 'FR', entityType: 'natural-person' });
@@ -312,12 +312,37 @@ describe('EUTinValidator', () => {
       expect(euTinValidator.sanitize('  1234  /-  abc ', { country: 'FR', entityType: 'natural-person' })).toBe('1234ABC');
     });
 
-    it('should remove unnecessary characters and to lower case', () => {
+    it('should remove unnecessary characters and to upper case', () => {
       expect(euTinValidator.sanitize('  1234  /-  abc ')).toBe('1234ABC');
     });
 
     it('should use custom sanitization pattern', () => {
       expect(euTinValidator.sanitize('1234-abc', { sanitizePattern: /[\d-]/g })).toBe('ABC');
+    });
+  });
+
+  describe('standardize()', () => {
+    it('should standardize value if country requires it', () => {
+      [
+        {
+          standardizedValue: '0000123A',
+          value: ' 1 2 3 a '
+        },
+        {
+          standardizedValue: '123456789',
+          value: ' 1 2 3 4 5 6 7 8 9 '
+        }
+      ].forEach(({ standardizedValue, value }) => {
+        expect(euTinValidator.standardize(value, { country: 'MT', entityType: 'natural-person' })).toBe(standardizedValue);
+      });
+    });
+
+    it('should not standardize value if country requires it but value is already standardized', () => {
+      expect(euTinValidator.standardize('0000123A', { country: 'MT', entityType: 'natural-person' })).toBe('0000123A');
+    });
+
+    it('should not standardize value if country does not require it', () => {
+      expect(euTinValidator.standardize('12345678901', { country: 'BE', entityType: 'natural-person' })).toBe('12345678901');
     });
   });
 });


### PR DESCRIPTION
PR adds a new method `standardize`. Method returns the official version of a TIN, as validators may accept formatting variations. This is specially added for MT TIN which may accept TINS without prefixes of zeros.

https://uphold.atlassian.net/browse/BKO-6566